### PR TITLE
Return a 0 exit code on skip

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,11 @@ NEXT_TAG="$3"
 
 echo ::Executing bumper guard ::debug release_branch=${RELEASE_BRANCH},github_event_path=${GITHUB_EVENT_PATH}
 /bumper guard "${RELEASE_BRANCH}" "${GITHUB_EVENT_PATH}"
+if [ $? -eq 78 ]
+then
+    echo ::debug ::Guard returned a neutral code, stopping the execution.
+    exit 0
+fi
 
 if [ -z "${NEXT_TAG}" ]
 then


### PR DESCRIPTION
Since we currently have no way to tell github that the action exited with a "neutral" or "skip" status, we work around that limitation by returning `0`