### PR TITLE
allow to specify default increment bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ additional setup is required.
 release ; `tag`: creates a lightweight tag ; `none`: computes the next
 [SemVer](https://semver.org/) version but does not create a release or tag).
 
+### `default_increment`
+
+**Required** Default increment (skip/patch/minor/major). Default `"skip"`.
+
 ### `tag_format`
 
 **Optional** Format used to create tags. Default `"v%major%.%minor%.%patch%"`.

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: true
     default: release
 
+  default_increment:
+    description: 'Default increment (skip/patch/minor/major)'
+    required: true
+    default: skip
+
   tag_format:
     description: 'Format used to create tags'
     required: true
@@ -38,3 +43,4 @@ runs:
     - ${{ inputs.release_strategy }}
     - ${{ inputs.tag }}
     - ${{ inputs.tag_format }}
+    - ${{ inputs.default_increment }}

--- a/action.yml.dist
+++ b/action.yml.dist
@@ -17,6 +17,11 @@ inputs:
     required: true
     default: release
 
+  default_increment:
+    description: 'Default increment (skip/patch/minor/major)'
+    required: true
+    default: skip
+
   tag_format:
     description: 'Format used to create tags'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ RELEASE_BRANCH="$1"
 RELEASE_STRATEGY="$2"
 NEXT_TAG="$3"
 TAG_FORMAT="$4"
+DEFAULT_INCREMENT="$5"
 
 echo ::Executing bumper guard ::debug release_branch=${RELEASE_BRANCH},github_event_path=${GITHUB_EVENT_PATH}
 /bumper guard "${RELEASE_BRANCH}" "${GITHUB_EVENT_PATH}"
@@ -27,10 +28,16 @@ then
     LATEST_TAG=$(/bumper latest-tag "${GITHUB_REPOSITORY}" "${GITHUB_TOKEN}")
 
     echo ::debug ::Executing bumper increment github_event_path=${GITHUB_EVENT_PATH}
-    INCREMENT=$(/bumper increment "${GITHUB_EVENT_PATH}")
+    INCREMENT=$(/bumper increment "${DEFAULT_INCREMENT}" "${GITHUB_EVENT_PATH}")
 
     echo ::debug ::Executing bumper semver latest_tag=${LATEST_TAG},increment=${INCREMENT}
     NEXT_TAG=$(/bumper semver "${LATEST_TAG}" "${INCREMENT}" "${TAG_FORMAT}")
+
+    if [ "${LATEST_TAG}" = "${NEXT_TAG}" ]; then
+        echo ::debug ::Detected noop increment - skipping bumper release github_repository=${GITHUB_REPOSITORY},next_tag=${NEXT_TAG}
+        echo ::set-output name=tag::${NEXT_TAG}
+        exit 0
+    fi
 fi
 
 echo ::debug ::Executing bumper release github_repository=${GITHUB_REPOSITORY},github_sha=${GITHUB_SHA},next_tag=${NEXT_TAG},strategy=${RELEASE_STRATEGY}

--- a/internal/pkg/event/guard.go
+++ b/internal/pkg/event/guard.go
@@ -20,8 +20,8 @@ func GuardCommand() *cobra.Command {
 
 func IncrementCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:  "increment [GH_EVENT_PATH]",
-		Args: cobra.ExactArgs(1),
+		Use:  "increment [DEFAULT_INCREMENT] [GH_EVENT_PATH]",
+		Args: cobra.ExactArgs(2),
 		Run:  executeIncrement,
 	}
 }
@@ -58,11 +58,17 @@ func executeGuard(cmd *cobra.Command, args []string) {
 }
 
 func executeIncrement(cmd *cobra.Command, args []string) {
-	event := parseEvent(cmd, args[0])
+	defaultIncrementArg := args[0]
+	event := parseEvent(cmd, args[1])
+
+	defaultIncrement, err := semver.ParseIncrement(defaultIncrementArg)
+	if err != nil {
+		action.Fail(cmd, "no valid default_increment found")
+	}
 
 	increment, found := extractIncrement(cmd, event.PullRequest)
 	if !found {
-		action.Fail(cmd, "no valid semver label found")
+		increment = defaultIncrement
 	}
 
 	cmd.Print(increment)

--- a/internal/pkg/semver/model.go
+++ b/internal/pkg/semver/model.go
@@ -14,6 +14,7 @@ var ErrInvalidIncrement = errors.New("invalid increment")
 type Increment string
 
 const (
+	IncrementSkip  Increment = "skip"
 	IncrementPatch Increment = "patch"
 	IncrementMinor Increment = "minor"
 	IncrementMajor Increment = "major"
@@ -79,6 +80,8 @@ func ParseVersion(input string) (Version, error) {
 
 func ParseIncrement(inc string) (Increment, error) {
 	switch strings.ToLower(inc) {
+	case "skip":
+		return IncrementSkip, nil
 	case "patch":
 		return IncrementPatch, nil
 	case "minor":

--- a/internal/pkg/semver/model_test.go
+++ b/internal/pkg/semver/model_test.go
@@ -16,6 +16,12 @@ func TestVersionBump(t *testing.T) {
 		expectedVersion string
 	}{
 		{
+			name:            "skip bump",
+			version:         Version{major: 1, minor: 2, patch: 3},
+			increment:       IncrementSkip,
+			expectedVersion: "v1.2.3",
+		},
+		{
 			name:            "patch bump",
 			version:         Version{major: 1, minor: 2, patch: 3},
 			increment:       IncrementPatch,
@@ -68,6 +74,11 @@ func TestParseIncrement(t *testing.T) {
 		expectedIncrement Increment
 		expectedError     error
 	}{
+		{
+			input:             "skip",
+			expectedIncrement: IncrementSkip,
+			expectedError:     nil,
+		},
 		{
 			input:             "patch",
 			expectedIncrement: IncrementPatch,


### PR DESCRIPTION
This PR adds new parameter `default_increment` allowing to bump without any label defined.

For backward compatibility default value is `skip` meaning there won't be any release. The only difference may be with graceful closure (exit 0).

Closes: https://github.com/K-Phoen/semver-release-action/issues/26