### PR TITLE
Fix wrong yaml syntax for `on.pull_request.type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ name: Release
 
 on:
   pull_request:
-    types: closed
+    types:
+      - closed
 
 jobs:
   build:


### PR DESCRIPTION
Looks like the syntax in the example is slightly wrong, based on the documentation here:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request

Noticed in vscode:

![2021-09-02_10-30](https://user-images.githubusercontent.com/7545665/131868931-0f3cb324-389e-4fa1-ad64-15ae5aa8c42b.png)
