### PR TITLE
Allow incrementation of release tag according to the tag format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 if [ -z "${NEXT_TAG}" ]
 then
     echo ::debug ::Executing bumper latest-tag github_repository=${GITHUB_REPOSITORY}
-    LATEST_TAG=$(/bumper latest-tag "${GITHUB_REPOSITORY}" "${GITHUB_TOKEN}")
+    LATEST_TAG=$(/bumper latest-tag "${GITHUB_REPOSITORY}" "${GITHUB_TOKEN}" "${TAG_FORMAT}")
 
     echo ::debug ::Executing bumper increment github_event_path=${GITHUB_EVENT_PATH}
     INCREMENT=$(/bumper increment "${GITHUB_EVENT_PATH}")

--- a/internal/pkg/git/git.go
+++ b/internal/pkg/git/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+    "regexp"
 
 	"github.com/K-Phoen/semver-release-action/internal/pkg/action"
 	"github.com/blang/semver"
@@ -14,15 +15,26 @@ import (
 
 func LatestTagCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:  "latest-tag [REPOSITORY] [GH_TOKEN]",
-		Args: cobra.ExactArgs(2),
+		Use:  "latest-tag [REPOSITORY] [GH_TOKEN] [TAG_FORMAT]",
+		Args: cobra.ExactArgs(3),
 		Run:  executeLatestTag,
 	}
+}
+
+func createRegexFromTagFormat(tagFormat string) string {
+	tagFormatRegex := strings.ReplaceAll(tagFormat, "%major%", "\\d+")
+	tagFormatRegex = strings.ReplaceAll(tagFormatRegex, "%minor%", "\\d+")
+	tagFormatRegex = strings.ReplaceAll(tagFormatRegex, "%patch%", "\\d+")
+	tagFormatRegex = "^" + tagFormatRegex
+	tagFormatRegex = tagFormatRegex + "$"
+
+	return tagFormatRegex
 }
 
 func executeLatestTag(cmd *cobra.Command, args []string) {
 	repository := args[0]
 	githubToken := args[1]
+	tagFormat := args[2]
 
 	ctx := context.Background()
 
@@ -43,8 +55,15 @@ func executeLatestTag(cmd *cobra.Command, args []string) {
 	action.AssertNoError(cmd, err, "could not list git refs: %s", err)
 
 	latest := semver.MustParse("0.0.0")
+	tagFormatRegex := createRegexFromTagFormat(tagFormat)
+
 	for _, ref := range refs {
-		version, err := semver.ParseTolerant(strings.Replace(*ref.Ref, "refs/tags/", "", 1))
+		versionStr := strings.Replace(*ref.Ref, "refs/tags/", "", 1)
+		formatValid, _ := regexp.MatchString(tagFormatRegex, versionStr)
+		if formatValid != true {
+			continue
+		}
+		version, err := semver.ParseTolerant(versionStr)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Allow multiple semver incremental systems based on tag format.
The PR introduces the ability to ignore release tags that are not in the provided tag format so it will increment only based on tags that are in the provided tag format. 
Suggestion for solving issue #43