### PR TITLE
fix(guard) Do not throw error if no labels present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /bumper
+.vscode

--- a/internal/pkg/event/guard_test.go
+++ b/internal/pkg/event/guard_test.go
@@ -1,0 +1,29 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/K-Phoen/semver-release-action/internal/pkg/semver"
+	"github.com/google/go-github/github"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractLabelNoLabelsFound(t *testing.T) {
+	cases := []struct {
+		cmd cobra.Command
+		pullRequest github.PullRequest
+	}{
+		{
+			cmd:         cobra.Command{},
+			pullRequest: github.PullRequest{},
+		},
+	}
+
+	for _, testCase := range cases {
+		increment, success := extractIncrement(&testCase.cmd, &testCase.pullRequest)
+
+		require.Equal(t, increment, semver.Increment("patch"))
+		require.Equal(t, success, true)
+	}
+}


### PR DESCRIPTION
Fixes #46

- [x] add check if no labels present, and still consider it a guard (semver detection) a success
- [x] changed result variable name from `labelFound/etc` to `success` due to it does not mean that a label was found
- [x] add test
- [x] add vscode folder to gitignore

Previously, if you didn't add any labels to your pull request you'd get an error "no valid semver label found".
Not every PR may need to cause a semver label to be created when this github action is included in the workflow.

By checking the label list length, we can determine if there are any labels. If none present, do not throw error.

```bash
➜  semver-release-action git:(jm/fix-no-labels-throws-error) make test
go test -mod=vendor ./...
?   	github.com/K-Phoen/semver-release-action	[no test files]
?   	github.com/K-Phoen/semver-release-action/internal/pkg/action	[no test files]
ok  	github.com/K-Phoen/semver-release-action/internal/pkg/event	0.842s
?   	github.com/K-Phoen/semver-release-action/internal/pkg/git	[no test files]
?   	github.com/K-Phoen/semver-release-action/internal/pkg/release	[no test files]
ok  	github.com/K-Phoen/semver-release-action/internal/pkg/semver	0.429s
```

Note the 0.842s test run for pkg/event, that is the new test I've added

Signed-off-by: jmeridth <jmeridth@gmail.com>