### PR TITLE
fix: Switch to github_output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,4 +36,4 @@ fi
 echo ::debug ::Executing bumper release github_repository=${GITHUB_REPOSITORY},github_sha=${GITHUB_SHA},next_tag=${NEXT_TAG},strategy=${RELEASE_STRATEGY}
 /bumper release --strategy "${RELEASE_STRATEGY}" "${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${NEXT_TAG}" "${GITHUB_TOKEN}"
 
-echo ::set-output name=tag::${NEXT_TAG}
+echo echo "tag=${NEXT_TAG}" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,4 +36,4 @@ fi
 echo ::debug ::Executing bumper release github_repository=${GITHUB_REPOSITORY},github_sha=${GITHUB_SHA},next_tag=${NEXT_TAG},strategy=${RELEASE_STRATEGY}
 /bumper release --strategy "${RELEASE_STRATEGY}" "${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${NEXT_TAG}" "${GITHUB_TOKEN}"
 
-echo echo "tag=${NEXT_TAG}" >> $GITHUB_OUTPUT
+echo "tag=${NEXT_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Since ::set-output is deprecated and will be removed soon. 

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/